### PR TITLE
feat: add /clif-help command for assistance requests

### DIFF
--- a/workflow.md
+++ b/workflow.md
@@ -76,6 +76,15 @@ Displays a formatted table showing:
 
 The dashboard is posted publicly to #project-tracker for all users to view.
 
+### `/clif-help` - Request CLIF Assistance
+
+Opens a simple form for submitting help requests.
+
+- **Summary**: Brief description of the issue
+- **Details**: Longer explanation or question (supports multiline input)
+
+Submitted tickets are posted to **#clif-help** (configurable via `HELP_CHANNEL`) so the CLIF team can follow up.
+
 ---
 
 ## Workflow Process
@@ -117,10 +126,17 @@ The dashboard is posted publicly to #project-tracker for all users to view.
 
 ### 3. Status Tracking Flow
 
-1. **User runs `/clif-status`**  
+1. **User runs `/clif-status`**
 2. **Bot generates formatted table** from stored project data
 3. **Table posted publicly** to #project-tracker showing all site statuses
 4. **Status updates persist** through bot restarts via JSON storage
+
+### 4. Help Ticket Flow
+
+1. **User runs `/clif-help`**
+2. **Modal opens** requesting a summary and detailed description of the issue
+3. **Bot posts ticket** to #clif-help with the user's information
+4. **Team members follow up** in the channel to resolve the request
 
 ---
 


### PR DESCRIPTION
## Summary
- add `/clif-help` slash command that opens a help ticket modal and posts submissions to `#clif-help`
- document new help command and workflow in `workflow.md`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac1e8f493c83319fc0ce6db752f97f